### PR TITLE
Add automatic mode negotiation

### DIFF
--- a/nerfnet/net/nerfnet_main.cc
+++ b/nerfnet/net/nerfnet_main.cc
@@ -37,6 +37,86 @@ constexpr char kDescription[] =
 // The version of the program.
 constexpr char kVersion[] = "0.0.1";
 
+enum class RadioMode {
+  NotSet,
+  Primary,
+  Secondary,
+  Common,
+};
+
+// Auto Negotiation of the radio interface.
+RadioMode AutoNegotiateRadioInterface(uint16_t ce_pin, uint16_t channel, uint32_t discovery_address = 0xFFFABABA) {
+  
+  enum class PacketType {
+    Discovery = 0x1F,
+    DiscoverResponse = 0xA5,
+  };
+
+  RadioMode mode = RadioMode::NotSet;
+  RF24 radio_(ce_pin, 0);
+  uint32_t kMaxPacketSize = 32;
+  std::vector<uint8_t> request(kMaxPacketSize, 0);
+  request[0] = static_cast<uint8_t>(PacketType::Discovery);
+
+  CHECK(channel < 128, "Channel must be between 0 and 127");
+  CHECK(radio_.begin(), "Failed to start NRF24L01");
+  radio_.setChannel(channel);
+  radio_.setPALevel(RF24_PA_MAX);
+  radio_.setDataRate(RF24_2MBPS);
+  radio_.setAddressWidth(3);
+  radio_.setAutoAck(1);
+  radio_.setRetries(0, 15);
+  radio_.setCRCLength(RF24_CRC_8);
+  CHECK(radio_.isChipConnected(), "NRF24L01 is unavailable");
+
+  radio_.openWritingPipe(discovery_address);
+  radio_.openReadingPipe(1, discovery_address);
+
+  //Transmit discovery packet
+  radio_.stopListening();
+
+  if (request.size() > kMaxPacketSize) {
+    LOGE("Request is too large (%zu vs %zu)", request.size(), kMaxPacketSize);
+  }
+
+  if (!radio_.write(request.data(), request.size())) {
+    LOGE("Failed to write request");
+  }
+
+  while (!radio_.txStandBy()) {
+    LOGI("Waiting for transmit standby");
+  }
+
+  //Receive
+  radio_.startListening();
+  while(1){
+    if(radio_.available()){
+      std::vector<uint8_t> response(kMaxPacketSize);
+      radio_.read(response.data(), response.size());
+      LOGI("Received %d bytes from the tunnel", response.size());
+      if (response.size() > 0) {
+        if (response[0] == static_cast<uint8_t>(PacketType::DiscoverResponse)) {
+          mode = RadioMode::Primary;
+          break;
+        } else if (response[0] == static_cast<uint8_t>(PacketType::Discovery)) {
+          mode = RadioMode::Secondary;
+          // Send back a discovery response
+          std::vector<uint8_t> response_packet(kMaxPacketSize, 0);
+          response_packet[0] = static_cast<uint8_t>(PacketType::DiscoverResponse);
+          radio_.stopListening();
+          if (!radio_.write(response_packet.data(), response_packet.size())) {
+            LOGE("Failed to send discovery response");
+          }
+          break;
+        }
+      }
+    }
+  }
+
+  return mode;
+}
+
+
 // Sets flags for a given interface. Quits and logs the error on failure.
 void SetInterfaceFlags(const std::string_view& device_name, int flags) {
   int fd = socket(AF_INET, SOCK_DGRAM, 0);
@@ -94,6 +174,7 @@ int OpenTunnel(const std::string_view& device_name) {
 }
 
 int main(int argc, char** argv) {
+  RadioMode mode = RadioMode::NotSet;
   // Parse command-line arguments.
   TCLAP::CmdLine cmd(kDescription, ' ', kVersion);
   TCLAP::ValueArg<std::string> interface_name_arg("i", "interface_name",
@@ -105,13 +186,16 @@ int main(int argc, char** argv) {
       "Run this side of the network in primary mode.", false);
   TCLAP::SwitchArg secondary_arg("", "secondary",
       "Run this side of the network in secondary mode.", false);
+  TCLAP::SwitchArg common_arg("", "common",
+      "Run this side of the network in common mode.", false);
   TCLAP::ValueArg<std::string> tunnel_ip_arg("", "tunnel_ip",
       "The IP address to assign to the tunnel interface.", false, "", "ip",
       cmd);
   TCLAP::ValueArg<std::string> tunnel_ip_mask("", "tunnel_mask",
       "The network mask to use for the tunnel interface.", false,
       "255.255.255.0", "mask", cmd);
-  cmd.xorAdd(primary_arg, secondary_arg);
+  std::vector<TCLAP::Arg*> xor_args = {&primary_arg, &secondary_arg, &common_arg};
+  cmd.xorAdd(xor_args);
   TCLAP::ValueArg<uint32_t> primary_addr_arg("", "primary_addr",
       "The address to use for the primary side of nerfnet.",
       false, 0x90019001, "address", cmd);
@@ -127,11 +211,27 @@ int main(int argc, char** argv) {
       "Set to enable verbose logs for read/writes from the tunnel.", cmd);
   cmd.parse(argc, argv);
 
+  if (primary_arg.getValue())
+  {
+    mode = RadioMode::Primary;
+  }
+  else if (secondary_arg.getValue())
+  {
+    mode = RadioMode::Secondary;
+  }
+  else
+  {
+    LOGI("Negotiating Radio Roles");
+    mode = AutoNegotiateRadioInterface(ce_pin_arg.getValue(), channel_arg.getValue());
+    CHECK(mode != RadioMode::NotSet, "Failed to negotiate radio roles");
+    LOGI("Negotiated Radio Roles: %s", mode == RadioMode::Primary ? "Primary" : "Secondary");
+  }
+
   std::string tunnel_ip = tunnel_ip_arg.getValue();
   if (!tunnel_ip_arg.isSet()) {
-    if (primary_arg.getValue()) {
+    if (mode == RadioMode::Primary) {
       tunnel_ip = "192.168.10.1";
-    } else if (secondary_arg.getValue()) {
+    } else if (mode == RadioMode::Secondary) {
       tunnel_ip = "192.168.10.2";
     }
   }
@@ -147,14 +247,14 @@ int main(int argc, char** argv) {
        interface_name_arg.getValue().c_str(), tunnel_ip.c_str(),
        tunnel_ip_mask.getValue().c_str());
 
-  if (primary_arg.getValue()) {
+  if (mode == RadioMode::Primary) {
     nerfnet::PrimaryRadioInterface radio_interface(
         ce_pin_arg.getValue(), tunnel_fd,
         primary_addr_arg.getValue(), secondary_addr_arg.getValue(),
         channel_arg.getValue(), poll_interval_us_arg.getValue());
     radio_interface.SetTunnelLogsEnabled(enable_tunnel_logs_arg.getValue());
     radio_interface.Run();
-  } else if (secondary_arg.getValue()) {
+  } else if (mode == RadioMode::Secondary) {
     nerfnet::SecondaryRadioInterface radio_interface(
         ce_pin_arg.getValue(), tunnel_fd,
         primary_addr_arg.getValue(), secondary_addr_arg.getValue(),

--- a/nerfnet/net/nerfnet_main.cc
+++ b/nerfnet/net/nerfnet_main.cc
@@ -186,15 +186,15 @@ int main(int argc, char** argv) {
       "Run this side of the network in primary mode.", false);
   TCLAP::SwitchArg secondary_arg("", "secondary",
       "Run this side of the network in secondary mode.", false);
-  TCLAP::SwitchArg common_arg("", "common",
-      "Run this side of the network in common mode.", false);
+  TCLAP::SwitchArg auto_negotiation_arg("", "auto",
+      "Automatically negotiate the mode", false);
   TCLAP::ValueArg<std::string> tunnel_ip_arg("", "tunnel_ip",
       "The IP address to assign to the tunnel interface.", false, "", "ip",
       cmd);
   TCLAP::ValueArg<std::string> tunnel_ip_mask("", "tunnel_mask",
       "The network mask to use for the tunnel interface.", false,
       "255.255.255.0", "mask", cmd);
-  std::vector<TCLAP::Arg*> xor_args = {&primary_arg, &secondary_arg, &common_arg};
+  std::vector<TCLAP::Arg*> xor_args = {&primary_arg, &secondary_arg, &auto_negotiation_arg};
   cmd.xorAdd(xor_args);
   TCLAP::ValueArg<uint32_t> primary_addr_arg("", "primary_addr",
       "The address to use for the primary side of nerfnet.",


### PR DESCRIPTION
This PR adds auto negotiation. On boot, each side sends a discovery message and starts listening. The next program to run sends a discovery message that the first one will receive. Based on the boot order, each side will take a different mode. 